### PR TITLE
Corrected RainViewer API Call

### DIFF
--- a/Clock/PyQtPiClock.py
+++ b/Clock/PyQtPiClock.py
@@ -1709,12 +1709,12 @@ class Radar(QtWidgets.QLabel):
                     radar['smooth'] = 1
                 if 'snow' not in radar:
                     radar['snow'] = 1
-                tail = '/256/%d/%d/%d/%d/%d_%d.png' % (self.zoom, x, y,
+                tail = '256/%d/%d/%d/%d/%d_%d.png' % (self.zoom, x, y,
                                                        radar['color'],
                                                        radar['smooth'],
                                                        radar['snow'])
                 if 'oldcolor' in radar:
-                    tail = '/256/%d/%d/%d.png?color=%d' % (self.zoom, x, y,
+                    tail = '256/%d/%d/%d.png?color=%d' % (self.zoom, x, y,
                                                            radar['color'])
                 self.tiletails.append(tail)
         for x in range(int(self.cornerTiles['NW']['X']),
@@ -2671,3 +2671,4 @@ w.show()
 w.showFullScreen()
 
 sys.exit(app.exec_())
+


### PR DESCRIPTION
Removed extraneous slash in the tail of the RainViewer API call URL, which used to be ignored by RainViewer but now causes an invalid response.