### PR TITLE
Changed default radar zoom level

### DIFF
--- a/Clock/Config-Example-Bedside.py
+++ b/Clock/Config-Example-Bedside.py
@@ -191,7 +191,7 @@ radar1 = {
 
 radar2 = {
     'center': radar_location,
-    'zoom': 11,
+    'zoom': 7,
     'basemap': map_base,
     'overlay': map_overlay,
     'color': 2,
@@ -229,7 +229,7 @@ radar3 = {
 
 radar4 = {
     'center': radar_location,
-    'zoom': 11,
+    'zoom': 7,
     'basemap': map_base,
     'overlay': map_overlay,
     'color': 2,

--- a/Clock/Config-Example-Berlin.py
+++ b/Clock/Config-Example-Berlin.py
@@ -193,7 +193,7 @@ radar1 = {
 
 radar2 = {
     'center': radar_location,
-    'zoom': 11,
+    'zoom': 7,
     'basemap': map_base,
     'overlay': map_overlay,
     'color': 2,
@@ -231,7 +231,7 @@ radar3 = {
 
 radar4 = {
     'center': radar_location,
-    'zoom': 11,
+    'zoom': 7,
     'basemap': map_base,
     'overlay': map_overlay,
     'color': 2,

--- a/Clock/Config-Example-London.py
+++ b/Clock/Config-Example-London.py
@@ -192,7 +192,7 @@ radar1 = {
 
 radar2 = {
     'center': radar_location,
-    'zoom': 11,
+    'zoom': 7,
     'basemap': map_base,
     'overlay': map_overlay,
     'color': 2,
@@ -230,7 +230,7 @@ radar3 = {
 
 radar4 = {
     'center': radar_location,
-    'zoom': 11,
+    'zoom': 7,
     'basemap': map_base,
     'overlay': map_overlay,
     'color': 2,

--- a/Clock/Config-Example.py
+++ b/Clock/Config-Example.py
@@ -192,7 +192,7 @@ radar1 = {
 
 radar2 = {
     'center': radar_location,
-    'zoom': 11,
+    'zoom': 7,
     'basemap': map_base,
     'overlay': map_overlay,
     'color': 2,
@@ -230,7 +230,7 @@ radar3 = {
 
 radar4 = {
     'center': radar_location,
-    'zoom': 11,
+    'zoom': 7,
     'basemap': map_base,
     'overlay': map_overlay,
     'color': 2,


### PR DESCRIPTION
Note from RainViewer (https://www.rainviewer.com/api/transition-faq.html) - January 1, 2026: All users (including Patrons) are limited to 100 requests per IP per minute and zoom level 7 as part of the final transition.